### PR TITLE
[prometheus-logstash-exporter] Fix nindent in servicemonitor.yaml

### DIFF
--- a/charts/prometheus-logstash-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-logstash-exporter/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:
-      {{- include "prometheus-logstash-exporter.selectorLabels" . | nindent 4 }}
+      {{- include "prometheus-logstash-exporter.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
`helm diff` fails with 
```
Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/instance" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/name" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector]
```
Because wrong nindent 4 -> 6
`{{- include "prometheus-logstash-exporter.selectorLabels" . | nindent 6 }}`